### PR TITLE
Fix crash bug with Merged::Annul

### DIFF
--- a/src/record.rs
+++ b/src/record.rs
@@ -204,6 +204,7 @@ impl<A: Action, F: FnMut(Signal)> Record<A, F> {
             Merged::Yes => true,
             Merged::Annul => {
                 self.entries.pop_back();
+                current -= 1;
                 true
             }
             // If actions are not merged or annulled push it onto the record.

--- a/src/record.rs
+++ b/src/record.rs
@@ -204,7 +204,7 @@ impl<A: Action, F: FnMut(Signal)> Record<A, F> {
             Merged::Yes => true,
             Merged::Annul => {
                 self.entries.pop_back();
-                current -= 1;
+                self.current -= 1;
                 true
             }
             // If actions are not merged or annulled push it onto the record.


### PR DESCRIPTION
Fix crash bug when merged entries annul each other:
`(a -> b) | (b -> a) => nil` needs to decrement the `current` counter, otherwise the next `apply()` operation will crash on at record.rs:195