### PR TITLE
feat: add blanket implementation of `Action` for `DerefMut`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,24 @@ pub trait Action {
     }
 }
 
+impl<A, D> Action for D
+where
+    A: Action + ?Sized,
+    D: core::ops::DerefMut<Target = A>
+{
+    type Target = A::Target;
+    type Output = A::Output;
+    type Error = A::Error;
+
+    fn apply(&mut self, target: &mut Self::Target) -> Result<Self> {
+        self.deref_mut().apply(target)
+    }
+
+    fn undo(&mut self, target: &mut Self::Target) -> Result<Self> {
+        self.deref_mut().undo(target)
+    }
+}
+
 /// Says if the action have been merged with another action.
 #[cfg_attr(
     feature = "serde",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,10 @@ where
     fn undo(&mut self, target: &mut Self::Target) -> Result<Self> {
         self.deref_mut().undo(target)
     }
+
+    fn redo(&mut self, target: &mut Self::Target) -> Result<Self> {
+        self.deref_mut().redo(target)
+    }
 }
 
 /// Says if the action have been merged with another action.


### PR DESCRIPTION
This enables `Action` trait objects to work, for instance `undo::Record<Box<dyn undo::Action<...>>>`. Without this, Rust compiler says:

```
the method `apply` exists for struct `undo::Record<Box<(dyn Action<Output = (), Target = State, Error = &'static str> + 'static)>>`, but its trait bounds were not satisfied
the following trait bounds were not satisfied:
`Box<(dyn Action<Output = (), Target = State, Error = &'static str> + 'static)>: Action`
```