### PR TITLE
Use Output as full return type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,4 @@ serde = ["dep:serde", "time?/serde"]
 maintenance = { status = "actively-developed" }
 
 [package.metadata.docs.rs]
-features = ["time", "serde"]
+features = ["serde", "time"]

--- a/README.md
+++ b/README.md
@@ -21,33 +21,30 @@ struct Push(char);
 impl Action for Push {
     type Target = String;
     type Output = ();
-    type Error = &'static str;
 
-    fn apply(&mut self, s: &mut String) -> Result<(), &'static str> {
+    fn apply(&mut self, s: &mut String) {
         s.push(self.0);
-        Ok(())
     }
 
-    fn undo(&mut self, s: &mut String) -> Result<(), &'static str> {
-        self.0 = s.pop().ok_or("s is empty")?;
-        Ok(())
+    fn undo(&mut self, s: &mut String) {
+        self.0 = s.pop().expect("s is empty");
     }
 }
 
 fn main() {
     let mut target = String::new();
     let mut history = History::new();
-    history.apply(&mut target, Push('a')).unwrap();
-    history.apply(&mut target, Push('b')).unwrap();
-    history.apply(&mut target, Push('c')).unwrap();
+    history.apply(&mut target, Push('a'));
+    history.apply(&mut target, Push('b'));
+    history.apply(&mut target, Push('c'));
     assert_eq!(target, "abc");
-    history.undo(&mut target).unwrap().unwrap();
-    history.undo(&mut target).unwrap().unwrap();
-    history.undo(&mut target).unwrap().unwrap();
+    history.undo(&mut target);
+    history.undo(&mut target);
+    history.undo(&mut target);
     assert_eq!(target, "");
-    history.redo(&mut target).unwrap().unwrap();
-    history.redo(&mut target).unwrap().unwrap();
-    history.redo(&mut target).unwrap().unwrap();
+    history.redo(&mut target);
+    history.redo(&mut target);
+    history.redo(&mut target);
     assert_eq!(target, "abc");
 }
 ```

--- a/push.rs
+++ b/push.rs
@@ -3,15 +3,12 @@ pub struct Push(char);
 impl undo::Action for Push {
     type Target = String;
     type Output = ();
-    type Error = &'static str;
 
-    fn apply(&mut self, s: &mut String) -> Result<(), &'static str> {
+    fn apply(&mut self, s: &mut String) {
         s.push(self.0);
-        Ok(())
     }
 
-    fn undo(&mut self, s: &mut String) -> Result<(), &'static str> {
-        self.0 = s.pop().ok_or("s is empty")?;
-        Ok(())
+    fn undo(&mut self, s: &mut String) {
+        self.0 = s.pop().unwrap();
     }
 }

--- a/src/any.rs
+++ b/src/any.rs
@@ -7,7 +7,7 @@ use core::fmt::{self, Debug, Formatter};
 /// Any action type.
 ///
 /// This allows you to use multiple different actions in a record or history
-/// as long as they all share the same target, output, and error type.
+/// as long as they all share the same target and output type.
 pub struct AnyAction<T, O> {
     id: u64,
     action: Box<dyn Action<Target = T, Output = O>>,

--- a/src/history.rs
+++ b/src/history.rs
@@ -159,9 +159,6 @@ impl<A, S> History<A, S> {
 impl<A: Action, S: Slot> History<A, S> {
     /// Pushes the action to the top of the history and executes its [`apply`] method.
     ///
-    /// # Errors
-    /// If an error occur when executing [`apply`] the error is returned.
-    ///
     /// [`apply`]: trait.Action.html#tymethod.apply
     pub fn apply(&mut self, target: &mut A::Target, action: A) -> A::Output {
         let at = self.at();
@@ -194,9 +191,6 @@ impl<A: Action, S: Slot> History<A, S> {
     /// Calls the [`undo`] method for the active action
     /// and sets the previous one as the new active one.
     ///
-    /// # Errors
-    /// If an error occur when executing [`undo`] the error is returned.
-    ///
     /// [`undo`]: trait.Action.html#tymethod.undo
     pub fn undo(&mut self, target: &mut A::Target) -> Option<A::Output> {
         self.record.undo(target)
@@ -204,9 +198,6 @@ impl<A: Action, S: Slot> History<A, S> {
 
     /// Calls the [`redo`] method for the active action
     /// and sets the next one as the new active one.
-    ///
-    /// # Errors
-    /// If an error occur when executing [`redo`] the error is returned.
     ///
     /// [`redo`]: trait.Action.html#method.redo
     pub fn redo(&mut self, target: &mut A::Target) -> Option<A::Output> {
@@ -319,9 +310,6 @@ impl<A: Action, S: Slot> History<A, S> {
 
 impl<A: Action<Output = ()>, S: Slot> History<A, S> {
     /// Repeatedly calls [`undo`] or [`redo`] until the action in `branch` at `current` is reached.
-    ///
-    /// # Errors
-    /// If an error occur when executing [`undo`] or [`redo`] the error is returned.
     ///
     /// [`undo`]: trait.Action.html#tymethod.undo
     /// [`redo`]: trait.Action.html#method.redo
@@ -508,9 +496,6 @@ impl<A: Action<Output = ()>, S: Slot> Queue<'_, A, S> {
     }
 
     /// Applies the queued actions.
-    ///
-    /// # Errors
-    /// If an error occurs, it stops applying the actions and returns the error.
     pub fn commit(self, target: &mut A::Target) -> Option<()> {
         for action in self.actions {
             match action {
@@ -585,10 +570,6 @@ impl<A: Action<Output = ()>, S: Slot> Checkpoint<'_, A, S> {
     pub fn commit(self) {}
 
     /// Cancels the changes and consumes the checkpoint.
-    ///
-    /// # Errors
-    /// If an error occur when canceling the changes, the error is returned
-    /// and the remaining actions are not canceled.
     pub fn cancel(self, target: &mut A::Target) -> Option<()> {
         for action in self.actions.into_iter().rev() {
             match action {

--- a/src/history.rs
+++ b/src/history.rs
@@ -128,16 +128,6 @@ impl<A, S> History<A, S> {
         self.record.current()
     }
 
-    /// Returns a queue.
-    pub fn queue(&mut self) -> Queue<A, S> {
-        Queue::from(self)
-    }
-
-    /// Returns a checkpoint.
-    pub fn checkpoint(&mut self) -> Checkpoint<A, S> {
-        Checkpoint::from(self)
-    }
-
     /// Returns a structure for configurable formatting of the history.
     pub fn display(&self) -> Display<A, S> {
         Display::from(self)
@@ -332,6 +322,16 @@ impl<A: Action<Output = ()>, S: Slot> History<A, S> {
             }
         }
         self.record.go_to(target, current)
+    }
+
+    /// Returns a queue.
+    pub fn queue(&mut self) -> Queue<A, S> {
+        Queue::from(self)
+    }
+
+    /// Returns a checkpoint.
+    pub fn checkpoint(&mut self) -> Checkpoint<A, S> {
+        Checkpoint::from(self)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,33 +38,30 @@
 //! impl Action for Push {
 //!     type Target = String;
 //!     type Output = ();
-//!     type Error = &'static str;
 //!
-//!     fn apply(&mut self, s: &mut String) -> Result<(), &'static str> {
+//!     fn apply(&mut self, s: &mut String) {
 //!         s.push(self.0);
-//!         Ok(())
 //!     }
 //!
-//!     fn undo(&mut self, s: &mut String) -> Result<(), &'static str> {
-//!         self.0 = s.pop().ok_or("s is empty")?;
-//!         Ok(())
+//!     fn undo(&mut self, s: &mut String) {
+//!         self.0 = s.pop().expect("s is empty");
 //!     }
 //! }
 //!
 //! fn main() {
 //!     let mut target = String::new();
 //!     let mut history = History::new();
-//!     history.apply(&mut target, Push('a')).unwrap();
-//!     history.apply(&mut target, Push('b')).unwrap();
-//!     history.apply(&mut target, Push('c')).unwrap();
+//!     history.apply(&mut target, Push('a'));
+//!     history.apply(&mut target, Push('b'));
+//!     history.apply(&mut target, Push('c'));
 //!     assert_eq!(target, "abc");
-//!     history.undo(&mut target).unwrap().unwrap();
-//!     history.undo(&mut target).unwrap().unwrap();
-//!     history.undo(&mut target).unwrap().unwrap();
+//!     history.undo(&mut target);
+//!     history.undo(&mut target);
+//!     history.undo(&mut target);
 //!     assert_eq!(target, "");
-//!     history.redo(&mut target).unwrap().unwrap();
-//!     history.redo(&mut target).unwrap().unwrap();
-//!     history.redo(&mut target).unwrap().unwrap();
+//!     history.redo(&mut target);
+//!     history.redo(&mut target);
+//!     history.redo(&mut target);
 //!     assert_eq!(target, "abc");
 //! }
 //! ```
@@ -116,22 +113,20 @@ pub trait Action {
     type Target;
     /// The output type.
     type Output;
-    /// The error type.
-    type Error;
 
     /// Applies the action on the target and returns `Ok` if everything went fine,
     /// and `Err` if something went wrong.
-    fn apply(&mut self, target: &mut Self::Target) -> Result<Self::Output, Self::Error>;
+    fn apply(&mut self, target: &mut Self::Target) -> Self::Output;
 
     /// Restores the state of the target as it was before the action was applied
     /// and returns `Ok` if everything went fine, and `Err` if something went wrong.
-    fn undo(&mut self, target: &mut Self::Target) -> Result<Self::Output, Self::Error>;
+    fn undo(&mut self, target: &mut Self::Target) -> Self::Output;
 
     /// Reapplies the action on the target and return `Ok` if everything went fine,
     /// and `Err` if something went wrong.
     ///
     /// The default implementation uses the [`apply`](trait.Action.html#tymethod.apply) implementation.
-    fn redo(&mut self, target: &mut Self::Target) -> Result<Self::Output, Self::Error> {
+    fn redo(&mut self, target: &mut Self::Target) -> Self::Output {
         self.apply(target)
     }
 

--- a/src/record.rs
+++ b/src/record.rs
@@ -1,7 +1,7 @@
 //! A record of actions.
 
 use crate::entry::Entries;
-use crate::slot::{NoOp, Slot, SW};
+use crate::slot::{NoOp, Slot, Socket};
 use crate::{Action, At, Entry, Format, History, Timeline};
 use alloc::collections::VecDeque;
 use alloc::string::{String, ToString};
@@ -267,7 +267,7 @@ pub struct Builder<A, S = NoOp> {
     capacity: usize,
     limit: NonZeroUsize,
     saved: bool,
-    slot: SW<S>,
+    slot: Socket<S>,
     pd: PhantomData<A>,
 }
 
@@ -278,7 +278,7 @@ impl<A, S> Builder<A, S> {
             capacity: 0,
             limit: NonZeroUsize::new(usize::MAX).unwrap(),
             saved: true,
-            slot: SW::default(),
+            slot: Socket::default(),
             pd: PhantomData,
         }
     }
@@ -321,7 +321,7 @@ impl<A, S> Builder<A, S> {
 impl<A, S: Slot> Builder<A, S> {
     /// Connects the slot.
     pub fn connect(mut self, f: S) -> Builder<A, S> {
-        self.slot = SW::new(f);
+        self.slot = Socket::new(f);
         self
     }
 }

--- a/src/record.rs
+++ b/src/record.rs
@@ -156,9 +156,6 @@ impl<A, S> Record<A, S> {
 impl<A: Action, S: Slot> Record<A, S> {
     /// Pushes the action on top of the record and executes its [`apply`] method.
     ///
-    /// # Errors
-    /// If an error occur when executing [`apply`] the error is returned.
-    ///
     /// [`apply`]: trait.Action.html#tymethod.apply
     pub fn apply(&mut self, target: &mut A::Target, action: A) -> A::Output {
         let (output, _, _) = self.timeline.apply(target, action);
@@ -168,9 +165,6 @@ impl<A: Action, S: Slot> Record<A, S> {
     /// Calls the [`undo`] method for the active action and sets
     /// the previous one as the new active one.
     ///
-    /// # Errors
-    /// If an error occur when executing [`undo`] the error is returned.
-    ///
     /// [`undo`]: ../trait.Action.html#tymethod.undo
     pub fn undo(&mut self, target: &mut A::Target) -> Option<A::Output> {
         self.timeline.undo(target)
@@ -178,9 +172,6 @@ impl<A: Action, S: Slot> Record<A, S> {
 
     /// Calls the [`redo`] method for the active action and sets
     /// the next one as the new active one.
-    ///
-    /// # Errors
-    /// If an error occur when applying [`redo`] the error is returned.
     ///
     /// [`redo`]: trait.Action.html#method.redo
     pub fn redo(&mut self, target: &mut A::Target) -> Option<A::Output> {
@@ -205,9 +196,6 @@ impl<A: Action<Output = ()>, S: Slot> Record<A, S> {
     }
 
     /// Repeatedly calls [`undo`] or [`redo`] until the action at `current` is reached.
-    ///
-    /// # Errors
-    /// If an error occur when executing [`undo`] or [`redo`] the error is returned.
     ///
     /// [`undo`]: trait.Action.html#tymethod.undo
     /// [`redo`]: trait.Action.html#method.redo
@@ -396,9 +384,6 @@ impl<A: Action<Output = ()>, S: Slot> Queue<'_, A, S> {
     }
 
     /// Applies the queued actions.
-    ///
-    /// # Errors
-    /// If an error occurs, it stops applying the actions and returns the error.
     pub fn commit(self, target: &mut A::Target) -> Option<()> {
         for action in self.actions {
             match action {
@@ -474,10 +459,6 @@ impl<A: Action<Output = ()>, S: Slot> Checkpoint<'_, A, S> {
     pub fn commit(self) {}
 
     /// Cancels the changes and consumes the checkpoint.
-    ///
-    /// # Errors
-    /// If an error occur when canceling the changes, the error is returned
-    /// and the remaining actions are not canceled.
     pub fn cancel(self, target: &mut A::Target) -> Option<()> {
         for action in self.actions.into_iter().rev() {
             match action {

--- a/src/record.rs
+++ b/src/record.rs
@@ -126,16 +126,6 @@ impl<A, S> Record<A, S> {
         self.timeline.current
     }
 
-    /// Returns a queue.
-    pub fn queue(&mut self) -> Queue<A, S> {
-        Queue::from(self)
-    }
-
-    /// Returns a checkpoint.
-    pub fn checkpoint(&mut self) -> Checkpoint<A, S> {
-        Checkpoint::from(self)
-    }
-
     /// Returns a structure for configurable formatting of the record.
     pub fn display(&self) -> Display<A, S> {
         Display::from(self)
@@ -207,6 +197,16 @@ impl<A: Action<Output = ()>, S: Slot> Record<A, S> {
             .binary_search_by(|e| e.timestamp.cmp(to))
             .unwrap_or_else(identity);
         self.go_to(target, current)
+    }
+
+    /// Returns a queue.
+    pub fn queue(&mut self) -> Queue<A, S> {
+        Queue::from(self)
+    }
+
+    /// Returns a checkpoint.
+    pub fn checkpoint(&mut self) -> Checkpoint<A, S> {
+        Checkpoint::from(self)
     }
 }
 

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -43,11 +43,11 @@ impl Slot for NoOp {
 /// Slot wrapper that adds some additional functionality.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(transparent))]
 #[derive(Clone, Debug)]
-pub(crate) struct SW<S>(Option<S>);
+pub(crate) struct Socket<S>(Option<S>);
 
-impl<S> SW<S> {
-    pub const fn new(slot: S) -> SW<S> {
-        SW(Some(slot))
+impl<S> Socket<S> {
+    pub const fn new(slot: S) -> Socket<S> {
+        Socket(Some(slot))
     }
 
     pub fn connect(&mut self, slot: Option<S>) -> Option<S> {
@@ -59,13 +59,13 @@ impl<S> SW<S> {
     }
 }
 
-impl<S> Default for SW<S> {
+impl<S> Default for Socket<S> {
     fn default() -> Self {
-        SW(None)
+        Socket(None)
     }
 }
 
-impl<S: Slot> SW<S> {
+impl<S: Slot> Socket<S> {
     pub fn emit(&mut self, signal: Signal) {
         if let Some(slot) = &mut self.0 {
             slot.emit(signal);

--- a/src/timeline.rs
+++ b/src/timeline.rs
@@ -1,5 +1,5 @@
 use crate::entry::{Entries, Entry};
-use crate::slot::{NoOp, Signal, Slot, SW};
+use crate::slot::{NoOp, Signal, Slot, Socket};
 use crate::{Action, Merged};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -10,7 +10,7 @@ pub(crate) struct Timeline<E, S = NoOp> {
     pub entries: E,
     pub current: usize,
     pub saved: Option<usize>,
-    pub slot: SW<S>,
+    pub slot: Socket<S>,
 }
 
 impl<E: Entries, S> Timeline<E, S> {
@@ -53,6 +53,7 @@ where
             Some(last) if !was_saved => last.action.merge(action),
             _ => Merged::No(action),
         };
+
         let merged_or_annulled = match merged {
             Merged::Yes => true,
             Merged::Annul => {
@@ -73,6 +74,7 @@ where
                 false
             }
         };
+
         self.slot.emit_if(could_redo, Signal::Redo(false));
         self.slot.emit_if(!could_undo, Signal::Undo(true));
         self.slot.emit_if(was_saved, Signal::Saved(false));
@@ -153,6 +155,7 @@ where
         if current > self.entries.len() {
             return None;
         }
+
         let could_undo = self.can_undo();
         let could_redo = self.can_redo();
         let was_saved = self.is_saved();


### PR DESCRIPTION
This makes us unable to currently exit early on errors but simplifies the API a lot.

#17 